### PR TITLE
Fix Firestore card loading

### DIFF
--- a/lean_coffee_board.py
+++ b/lean_coffee_board.py
@@ -158,9 +158,13 @@ if board_id:
              .document(board_id) \
              .collection("cards") \
              .stream()
-    st.session_state['discussion_items'] = [
-        {"item": doc.id, **doc.to_dict()} for doc in docs
-    ]
+    # Preserve the order of the cards by sorting the documents by their
+    # numeric ID. Each document ID is saved as an integer string when
+    # writing to Firestore.
+    docs = sorted(docs, key=lambda d: int(d.id))
+    # Load the stored fields directly instead of using the document ID as
+    # the card content (which previously overwrote the real text).
+    st.session_state['discussion_items'] = [doc.to_dict() for doc in docs]
 else:
     st.session_state['discussion_items'] = []
 


### PR DESCRIPTION
## Summary
- avoid overwriting card text with document ID when loading from Firestore
- sort loaded documents by numeric ID to maintain order

## Testing
- `python -m py_compile lean_coffee_board.py`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_685d051d9a3c83339099bda1b902fa1a